### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Alan Grover
 maintainer=Alan Grover <awgrover@msen.com>
 sentence=Library for TI TLC59116 (and almost TLC59108) I2C Led Driver chip.
 paragraph=A high-level interface that manages multiple TLC59116 chips, with almost every function of the chip implemented. And, a lower-level interface that (allegedly) correctly implements the protocol for each function without the "manager" layer.
+category=Device Control
 url=https://github.com/2splat/arduino-TLC59116
 architectures=*


### PR DESCRIPTION
Missing category property caused the warning on every compilation:

WARNING: Category '' in library arduino_TLC59116 is not valid. Setting to 'Uncategorized'

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format